### PR TITLE
Updated earth engine pull files into remake format.

### DIFF
--- a/2_rsdata/src/5_surface_reflectance_pull.Rmd
+++ b/2_rsdata/src/5_surface_reflectance_pull.Rmd
@@ -18,7 +18,7 @@ opts_knit$set(root.dir='../..')
 
 This script takes the shouldered, filtered in situ water quality dataset pulled from the Water Quality Portal/LAGOS and extracts associated surface atmosphere reflectance values from Google Earth Engine.  The pulled reflectance values are the median pixel value of pixels with 80% water occurence (according to Pekel) within 120m of the provided lat/long of the in situ sample identified in the water quality dataset.
 
-*Reticulate uses the default python path for the local machine.  This python needs to be authorized with google earth engine and have the necessary packages installed.*  
+*Reticulate uses the default python path for the local machine.  This python needs to be authorized with google earth engine and have the necessary packages installed. To change the Python called by reticulate use use_pythion().For more information on Reticulate go to https://github.com/rstudio/reticulate*  
 ```{r Get Existing}
 
 ###Download the split wqp/lagos data to send up to GGE.  This is easier in R than python. Also create a list of existing reflectance csv's to filter whats been pulled down from gge already.
@@ -61,7 +61,7 @@ l8 = ee.ImageCollection('LANDSAT/LC08/C01/T1_SR')
 l7 = ee.ImageCollection('LANDSAT/LE07/C01/T1_SR')
 l5 = ee.ImageCollection('LANDSAT/LT05/C01/T1_SR')
 
-#Identify toa for use in sourced functions.
+#Identify collection for use in sourced functions.
 collection = 'SR'
 
 #Standardize band names between the various collections and aggregate 

--- a/2_rsdata/src/5a_6a_GEE_pull_functions.py
+++ b/2_rsdata/src/5a_6a_GEE_pull_functions.py
@@ -109,7 +109,6 @@ def sitePull(i):
   .set({"Swir1": lsout.get('Swir1')})\
   .set({"Swir2": lsout.get('Swir2')})\
   .set({"qa": lsout.get('qa')})\
-  .set({"pwater": lsout.get('occurrence')})\
   .set({"pixelCount": lsSample.reduceRegion(ee.Reducer.count(), sdist, 30).get('Blue')})\
   .set({'PATH': lsSample.get('WRS_PATH')})\
   .set({'ROW': lsSample.get('WRS_ROW')})

--- a/2_rsdata/src/6_toa_reflectance_pull.Rmd
+++ b/2_rsdata/src/6_toa_reflectance_pull.Rmd
@@ -16,9 +16,9 @@ opts_knit$set(root.dir='../..')
 
 ```
 
-This script takes the shouldered, filtered in situ water quality dataset pulled from the Water Quality Portal/LAGOS and extracts associated top of atmosphere reflectance values from Google Earth Engine.  The pulled reflectance values are the median pixel value of pixels with 80% water occurence (according to Pekel) within 120m of the provided lat/long of the in situ sample identified in the water quality dataset.
+This script is essentially the same as script 05 but utilizes the top-of atmosphere Landsat collections instead of surface reflectance.
 
-*Reticulate uses the default python path for the local machine.  This python needs to be authorized with google earth engine and have the necessary packages installed.*  
+*Reticulate uses the default python path for the local machine.  This python needs to be authorized with google earth engine and have the necessary packages installed. To change the Python called by reticulate use use_pythion().For more information on Reticulate go to https://github.com/rstudio/reticulate*   
 ```{r Get Existing}
 
 ###Download the split wqp/lagos data to send up to GGE.  This is easier in R than python. Also create a list of existing reflectance csv's to filter whats been pulled down from gge already.
@@ -61,7 +61,7 @@ l8 = ee.ImageCollection('LANDSAT/LC08/C01/T1_TOA')
 l7 = ee.ImageCollection('LANDSAT/LE07/C01/T1_TOA')
 l5 = ee.ImageCollection('LANDSAT/LT05/C01/T1_TOA').map(addPan)
 
-#Identify toa for use in sourced functions.
+#Identify collection for use in sourced functions.
 collection = 'TOA'
 
 #Standardize band names between the various collections and aggregate 


### PR DESCRIPTION
Take a look at these.  The python is all called via reticulate, and the major functions have been removed into a .py file thats sourced within the pull scripts.  There's some redundancy between toa and sr pulls, but not a horrible amount.  The scripts pull all existing data from the team drive and deposit the final pulled files into the team drive.